### PR TITLE
Added support for reading cmd from settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ In order for `php` to be executed by SublimeLinter, you must ensure that its pat
 
 Once `php` is installed and configured, you can proceed to install the SublimeLinter-php plugin if it is not yet installed.
 
+#### Specific Executable
+It is possible to specify the `php` executable that should be used to lint your code, taking precedence over the executable available in your PATH.
+
+##### Example:
+
+```json
+{
+    "SublimeLinter": {
+        "linters": {
+            "php": {
+                "cmd": "/path/to/php"
+            }
+        }
+    }
+}
+```
+
 ### Plugin installation
 Please use [Package Control](https://sublime.wbond.net/installation) to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we won’t cover that here.
 

--- a/linter.py
+++ b/linter.py
@@ -21,6 +21,7 @@ class PHP(Linter):
         r'^(?:Parse|Fatal) (?P<error>error):(\s*(?P<type>parse|syntax) error,?)?\s*'
         r'(?P<message>(?:unexpected \'(?P<near>[^\']+)\')?.*) in - on line (?P<line>\d+)'
     )
+    executable = 'php'
     error_stream = util.STREAM_STDOUT
 
     def split_match(self, match):
@@ -40,7 +41,7 @@ class PHP(Linter):
         if 'cmd' in settings:
             command = [settings.get('cmd')]
         else:
-            command = ['php']
+            command = [self.executable_path]
 
         command.append('-l')
         command.append('-n')

--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,6 @@ class PHP(Linter):
     """Provides an interface to php -l."""
 
     syntax = ('php', 'html')
-    cmd = 'php -l -n -d display_errors=On -d log_errors=Off'
     regex = (
         r'^(?:Parse|Fatal) (?P<error>error):(\s*(?P<type>parse|syntax) error,?)?\s*'
         r'(?P<message>(?:unexpected \'(?P<near>[^\']+)\')?.*) in - on line (?P<line>\d+)'
@@ -33,3 +32,21 @@ class PHP(Linter):
             message = 'parse error'
 
         return match, line, col, error, warning, message, near
+
+    def cmd(self):
+        """Read cmd from inline settings."""
+        settings = Linter.get_view_settings(self)
+
+        if 'cmd' in settings:
+            command = [settings.get('cmd')]
+        else:
+            command = ['php']
+
+        command.append('-l')
+        command.append('-n')
+        command.append('-d')
+        command.append('display_errors=On')
+        command.append('-d')
+        command.append('log_errors=Off')
+
+        return command


### PR DESCRIPTION
This simply adds support for reading cmd from settings.

Why: to override system's php and use a specific binary (note: using `paths` setting did not work for this).