### PR TITLE
Fix linter not using php.ini configuration

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -44,7 +44,8 @@ class PHP(Linter):
             command = [self.executable_path]
 
         command.append('-l')
-        command.append('-n')
+        command.append('-d')
+        command.append('error_reporting=-1')
         command.append('-d')
         command.append('display_errors=On')
         command.append('-d')


### PR DESCRIPTION
This also turns on error reporting by default.