### PR TITLE
Fixes for latest PHP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore
+/tests/

--- a/linter.py
+++ b/linter.py
@@ -46,12 +46,9 @@ class PHP(Linter):
     def split_match(self, match):
         """Return the components of the error."""
         result = super().split_match(match)
+        result['message'] = _filter_message(result.message)
 
-        match, line, col, error, warning, message, near = result
-
-        message = _filter_message(message)
-
-        return match, line, col, error, warning, message, near
+        return result
 
     def cmd(self):
         """Read cmd from inline settings."""

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,20 @@ import logging
 from SublimeLinter.lint import Linter, util
 
 
-logger = logging.getLogger('SublimeLinter.plugin.eslint')
+logger = logging.getLogger('SublimeLinter.plugin.php')
+
+
+def _filter_message(message):
+    if not message:
+        message = 'parse error'
+    else:
+        message = message.replace('Standard input code', '')
+        message = message.replace(' on ', '')
+        message = message.replace(' in -', '')
+        message = message.replace(' in ', '')
+        message = message.strip()
+
+    return message
 
 
 class PHP(Linter):
@@ -24,18 +37,19 @@ class PHP(Linter):
         'selector': 'source.php, text.html.basic'
     }
     regex = (
-        r'^(?:Parse|Fatal) (?P<error>error):(\s*(?P<type>parse|syntax) error,?)?\s*'
-        r'(?P<message>(?:unexpected \'(?P<near>[^\']+)\')?.*) (?:in - )?on line (?P<line>\d+)'
+        r'^(?P<error>Parse|Fatal) error:\s*'
+        r'(?P<message>((?:parse|syntax) error,?)?\s*(?:unexpected \'(?P<near>[^\']+)\')?.*) '
+        r'(?:in - )?on line (?P<line>\d+)'
     )
     error_stream = util.STREAM_STDOUT
 
     def split_match(self, match):
         """Return the components of the error."""
-        match, line, col, error, warning, message, near = super().split_match(match)
+        result = super().split_match(match)
 
-        # message might be empty, we have to supply a value
-        if match and match.group('type') == 'parse' and not message:
-            message = 'parse error'
+        match, line, col, error, warning, message, near = result
+
+        message = _filter_message(message)
 
         return match, line, col, error, warning, message, near
 

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,67 @@
+# flake8: noqa
+import unittest
+import re
+import importlib
+
+# Damn you dash separated module names!!!
+LinterModule = importlib.import_module('SublimeLinter-php.linter')
+Linter = LinterModule.PHP
+_filter_message = LinterModule._filter_message
+regex = Linter.regex
+
+
+class TestRegex(unittest.TestCase):
+
+    def assertMatch(self, string, expected):
+        match = re.match(regex, string)
+        self.assertIsNotNone(match)
+
+        # Hack to test message filtering.
+        actual = match.groupdict()
+        if 'message' in actual:
+            actual['message'] = _filter_message(actual['message'])
+
+        self.assertEqual(actual, expected)
+
+    def assertNoMatch(self, string):
+        self.assertIsNone(re.match(regex, string))
+
+    def test_no_errors(self):
+        self.assertNoMatch('No syntax errors detected in - ')
+        self.assertNoMatch('No syntax errors detected in - file.php')
+        self.assertNoMatch('No syntax errors detected in - /path/to/file.php')
+        self.assertNoMatch('No syntax errors detected in Standard input code')
+
+    def test_errors(self):
+        self.assertMatch(
+            'Parse error: syntax error, unexpected \'$this\' (T_VARIABLE) in - on line 14', {
+                'error': 'Parse',
+                'line': '14',
+                'message': 'syntax error, unexpected \'$this\' (T_VARIABLE)',
+                'near': '$this'
+                })
+
+        self.assertMatch(
+            'Parse error: syntax error, unexpected end of file in - on line 23', {
+                'error': 'Parse',
+                'line': '23',
+                'message': 'syntax error, unexpected end of file',
+                'near': None
+                })
+
+    def test_issue_29(self):
+        self.assertMatch(
+            'Parse error: syntax error, unexpected \'endwhile\' (T_ENDWHILE), expecting end of file in Standard input code on line 16', {
+                'error': 'Parse',
+                'line': '16',
+                'message': 'syntax error, unexpected \'endwhile\' (T_ENDWHILE), expecting end of file',
+                'near': 'endwhile'
+                })
+
+        self.assertMatch(
+            'Parse error: parse error in - on line 16', {
+                'error': 'Parse',
+                'line': '16',
+                'message': 'parse error',
+                'near': None
+                })

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,0 +1,9 @@
+{
+    "tests_dir" : "tests",
+    "pattern" : "test*.py",
+    "async": false,
+    "deferred": true,
+    "verbosity": 2,
+    "capture_console": true,
+    "output": null
+}


### PR DESCRIPTION
Includes some regex fixes for latest PHP versions and some improved error message filtering.

- Removes trailing text like "Standard input code", " in -", " on ",  in error messages in the status message 
- Fixes parsing some errors in newer versions of PHP

Re: https://github.com/SublimeLinter/SublimeLinter-php/issues/48#issuecomment-1181302475