### PR TITLE
Remove support of the (deprecated) cmd setting

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -53,17 +53,10 @@ class PHP(Linter):
     def cmd(self):
         """Read cmd from inline settings."""
         if 'cmd' in self.settings:
-            logger.warning('The setting `cmd` has been deprecated. '
-                           'Use `executable` instead.')
-            command = [self.settings.get('cmd')]
-        else:
-            command = ['php']
+            logger.warning(
+                'The setting `cmd` has been removed. '
+                'Use `executable` instead. '
+            )
+            return None
 
-        command.append('-l')
-        command.append('-n')
-        command.append('-d')
-        command.append('display_errors=On')
-        command.append('-d')
-        command.append('log_errors=Off')
-
-        return command
+        return ('php', '-l', '-n', '-d', 'display_errors=On', '-d', 'log_errors=Off')

--- a/messages.json
+++ b/messages.json
@@ -1,5 +1,6 @@
 {
     "install": "messages/install.txt",
     "1.1.0": "messages/1.1.0.txt",
-    "1.2.1": "messages/1.2.1.txt"
+    "1.2.1": "messages/1.2.1.txt",
+    "1.4.0": "messages/1.4.0.txt"
 }

--- a/messages/1.4.0.txt
+++ b/messages/1.4.0.txt
@@ -1,0 +1,14 @@
+SublimeLinter-php 1.4.0
+-----------------------
+
+The 'cmd' setting has finally been removed. As a reminder: the new name for the same thing is 'executable' which is also the common name for all linters in SublimeLinter land.
+
+{
+    "SublimeLinter": {
+        "linters": {
+            "php": {
+                "executable": "/path/to/php"
+            }
+        }
+    }
+}


### PR DESCRIPTION
`cmd` was deprecated since 16a0d47 (Deprecate 'cmd' setting, April
2018).