### PR TITLE
Add support for ST4

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -34,7 +34,7 @@ class PHP(Linter):
     """Provides an interface to php -l."""
 
     defaults = {
-        'selector': 'source.php, text.html.basic'
+        'selector': 'embedding.php, text.html.php, source.php, text.html.basic'
     }
     regex = (
         r'^(?P<error>Parse|Fatal) error:\s*'


### PR DESCRIPTION
The current selector does not match PHP scripts in Sublime Text 4, this adds support for it while maintaining compatibility with earlier versions